### PR TITLE
Updated NewBill Activity UI

### DIFF
--- a/app/src/main/res/layout/activity_new_bill.xml
+++ b/app/src/main/res/layout/activity_new_bill.xml
@@ -39,7 +39,7 @@
             <TextView
                 android:id="@+id/customer_name"
                 style="@style/TextAppearance.Compat.Notification.Info.Media"
-                android:layout_width="wrap_content"
+                android:layout_width="170dp"
                 android:layout_height="wrap_content"
                 android:layout_above="@id/customer_mobile_view_id"
                 android:layout_marginStart="20dp"
@@ -51,7 +51,7 @@
             <TextView
                 android:id="@+id/customer_address_text_view_id"
                 style="@style/TextAppearance.Compat.Notification.Info.Media"
-                android:layout_width="wrap_content"
+                android:layout_width="170dp"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/customer_mobile_view_id"
                 android:layout_alignStart="@id/customer_name"
@@ -63,7 +63,7 @@
             <TextView
                 android:id="@+id/customer_mobile_view_id"
                 style="@style/TextAppearance.Compat.Notification.Info.Media"
-                android:layout_width="wrap_content"
+                android:layout_width="170dp"
                 android:layout_height="wrap_content"
                 android:layout_alignStart="@id/customer_name"
                 android:layout_centerVertical="true"
@@ -76,9 +76,9 @@
                 android:id="@+id/bill_amount"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
                 android:layout_centerVertical="true"
-                android:layout_marginEnd="20dp"
+                android:layout_marginStart="10dp"
+                android:layout_toEndOf="@+id/customer_mobile_view_id"
                 android:text="@string/bill_amount_dummy_text"
                 android:textColor="@color/secondary"
                 android:textSize="34sp"


### PR DESCRIPTION
## Summary - New Feature/Bug Resolution
Updated the NewBill Activity UI so as to prevent the overlapping of Amount, Name, Number and Address TextViews.

## Root Cause
The width of these TextViews were not restricted and that is why these were overlapping.

## Details
- The width of the Textviews is now restricted to 170 dp. <br>
- Attached a screenshot for reference below
![Screenshot](https://user-images.githubusercontent.com/78429106/138381758-bd2c19f8-7c12-42ef-a72b-6e78c9866c14.jpeg)

## Checklist
- [x] I've read the [Contribution Guidelines](/CONTRIBUTING.md).
- [x] I've tested that the application is performing well and there is no breaking changes.

## Related Issues / Pull Requests
Resolves #1 
