### PR TITLE
Updated NewBill Activity UI

### DIFF
--- a/app/src/main/java/com/sushant/quickbills/activity/NewBillActivity.kt
+++ b/app/src/main/java/com/sushant/quickbills/activity/NewBillActivity.kt
@@ -24,6 +24,7 @@ import com.sushant.quickbills.model.Customer
 import com.sushant.quickbills.model.Item
 import com.sushant.quickbills.utils.createOrShowBillPDF
 import com.sushant.quickbills.utils.isNetworkAvailable
+import com.sushant.quickbills.utils.preprocessDisplayText
 import kotlinx.android.synthetic.main.activity_all_bills.*
 import kotlinx.android.synthetic.main.activity_new_bill.*
 import kotlinx.android.synthetic.main.pop_up_delete.view.*
@@ -190,7 +191,7 @@ class NewBillActivity : AppCompatActivity(), RecyclerParticularsAdapter.OnClickL
                 )
                 particularList.add(newParticularItem)
                 totalAmount += amount
-                bill_amount.text = getString(R.string.rupee, totalAmount)
+                bill_amount.text=(getString(R.string.rupee_symbol_only)+" "+preprocessDisplayText(totalAmount))
                 recyclerParticularsAdapter.notifyDataSetChanged()
                 dialog.dismiss()
             }

--- a/app/src/main/java/com/sushant/quickbills/utils/preprocessDisplayText.kt
+++ b/app/src/main/java/com/sushant/quickbills/utils/preprocessDisplayText.kt
@@ -1,0 +1,13 @@
+package com.sushant.quickbills.utils
+
+fun preprocessDisplayText(num: Double):String
+{
+    val str=num.toBigDecimal().toPlainString()
+    val preprocessedText=str.substring(0,1)+"."+str.substring(1,3)+"E"+(str.length-1).toBigDecimal().toPlainString()
+    if(num>99999999) {
+        return preprocessedText
+    }
+    else {
+        return str
+    }
+}

--- a/app/src/main/res/layout/activity_new_bill.xml
+++ b/app/src/main/res/layout/activity_new_bill.xml
@@ -39,7 +39,7 @@
             <TextView
                 android:id="@+id/customer_name"
                 style="@style/TextAppearance.Compat.Notification.Info.Media"
-                android:layout_width="wrap_content"
+                android:layout_width="170dp"
                 android:layout_height="wrap_content"
                 android:layout_above="@id/customer_mobile_view_id"
                 android:layout_marginStart="20dp"
@@ -51,7 +51,7 @@
             <TextView
                 android:id="@+id/customer_address_text_view_id"
                 style="@style/TextAppearance.Compat.Notification.Info.Media"
-                android:layout_width="wrap_content"
+                android:layout_width="170dp"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/customer_mobile_view_id"
                 android:layout_alignStart="@id/customer_name"
@@ -63,7 +63,7 @@
             <TextView
                 android:id="@+id/customer_mobile_view_id"
                 style="@style/TextAppearance.Compat.Notification.Info.Media"
-                android:layout_width="wrap_content"
+                android:layout_width="170dp"
                 android:layout_height="wrap_content"
                 android:layout_alignStart="@id/customer_name"
                 android:layout_centerVertical="true"
@@ -76,9 +76,9 @@
                 android:id="@+id/bill_amount"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
                 android:layout_centerVertical="true"
-                android:layout_marginEnd="20dp"
+                android:layout_marginStart="10dp"
+                android:layout_toEndOf="@+id/customer_mobile_view_id"
                 android:text="@string/bill_amount_dummy_text"
                 android:textColor="@color/secondary"
                 android:textSize="34sp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="bill_amount_dummy_text">₹ 0.0</string>
     <string name="amount_text">Amount</string>
     <string name="rupee">₹ %1$.1f</string>
+    <string name="rupee_symbol_only">₹</string>
     <string name="save_title">Save</string>
     <string name="exit_msg">Want to discard all data and exit?</string>
     <string name="exit_btn_text">Yes</string>


### PR DESCRIPTION
## Summary - New Feature/Bug Resolution
Updated the NewBill Activity UI so as to prevent the overlapping of TextViews and implemented a function which preprocesses the amount and displays it in exponential form if it is too large.

## Root Cause
The amount text was not being preprocessed and was being displaying as it was.

## Details
- The width of the Textviews is now restricted to 170 dp. <br>
- The amount text is now being preprocessed and if it is more than 8 digits then it is displayed in exponential form.
- Attached a screenshot for reference below
![Screenshot QuickBills](https://user-images.githubusercontent.com/78429106/138980387-3f4e1ed3-d8f4-4d20-bef0-f5d26bb7511d.jpeg)

## Checklist
- [x] I've read the [Contribution Guidelines](/CONTRIBUTING.md).
- [x] I've tested that the application is performing well and there is no breaking changes.

## Related Issues / Pull Requests
- Resolves #1
